### PR TITLE
docs: formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,25 @@ Type definitions for [WebLN](https://webbtc.dev/webln)
 
 1. Install package
 
-```bash
- npm install @webbtc/webln-types --save-dev # or yarn add @webbtc/webln-types --dev
-```
+   ```bash
+   npm install @webbtc/webln-types --save-dev # or yarn add @webbtc/webln-types --dev
+   ```
 
 2. Type definitions are now available through `window.webln` and importing from `"@webbtc/webln-types"`
 
-```javascript
-import { GetInfoResponse } from "@webbtc/webln-types";
-if (window.webln) {
-  (async () => {
-    await window.webln.enable();
-    const info: GetInfoResponse = await window.webln.getInfo();
-    console.log("Your node pubkey is", info.node.pubkey);
-  })();
-} else {
-  console.warn("WebLN not enabled");
-}
-```
+   ```typescript
+   import type { GetInfoResponse } from "@webbtc/webln-types";
+
+   if (window.webln) {
+     (async () => {
+       await window.webln.enable();
+       const info: GetInfoResponse = await window.webln.getInfo();
+       console.log("Your node pubkey is", info.node.pubkey);
+     })();
+   } else {
+     console.warn("WebLN not enabled");
+   }
+   ```
 
 _If you do not import any types from "@webbtc/webln-types" and just want to use window.webln, add the following line somewhere in your codebase (e.g. the main/index.tsx file) to ensure the types still get consumed:_
 


### PR DESCRIPTION
Just minor formatting:
- indenting the code-blocks
- mark code-block with ts instead of js
- use `import type ...`